### PR TITLE
Updated to remove the devDependency section when locking the bower.json.

### DIFF
--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -41,6 +41,9 @@ function lock(isVerbose) {
     bowerConfig.bowerLocker = {lastUpdated: (new Date()).toISOString(), lockedVersions: {}};
     bowerConfig.resolutions = {};
     bowerConfig.dependencies = {};
+    // Remove devDependency section to prevent version collision
+    delete bowerConfig.devDependencies;
+
     dependencies.forEach(function(dep) {
         // NOTE: Use dirName as the dependency name as it is more accurate than .bower.json properties
         var name = dep.dirName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-locker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A command-line tool for locking, unlocking, and validating locked bower files",
   "main": "bower-locker.js",
   "scripts": {


### PR DESCRIPTION
This prevents colliding versions as it was locking the devDependencies within the dependency section but leaving the unlocked devDependency.
