### PR TITLE
Fallback to release if commit does not exist

### DIFF
--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -13,7 +13,7 @@ var cwd = process.cwd();
 function mapDependencyData(bowerInfo) {
     return {
         name: bowerInfo.name,
-        commit: bowerInfo._resolution.commit,
+        commit: bowerInfo._resolution !== undefined ? bowerInfo._resolution.commit : undefined,
         release: bowerInfo._release,
         src: bowerInfo._source,
         originalSrc: bowerInfo._originalSource

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -47,8 +47,9 @@ function lock(isVerbose) {
     dependencies.forEach(function(dep) {
         // NOTE: Use dirName as the dependency name as it is more accurate than .bower.json properties
         var name = dep.dirName;
-        bowerConfig.dependencies[name] = dep.src + '#' + dep.commit; // _source
-        bowerConfig.resolutions[name] = dep.commit;
+        var version = dep.commit !== undefined ? dep.commit : dep.release;
+        bowerConfig.dependencies[name] = dep.src + '#' + version; // _source
+        bowerConfig.resolutions[name] = version;
         bowerConfig.bowerLocker.lockedVersions[name] = dep.release;
         if (isVerbose) {
             console.log('  %s (%s): %s', name, dep.release, dep.commit);


### PR DESCRIPTION
Sometimes commit is not set in the JSON. If it happens, we should fall back to another solution, for example to the release number.