### PR TITLE
Ignore invalid Bower folders

### DIFF
--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -63,6 +63,8 @@ function getBowerFolder() {
 function getAllDependencies() {
     var folder = './' + getBowerFolder();
     var bowerDependencies = fs.readdirSync(folder, {encoding: 'utf8'});
+
+    var dependencyInfos = [];
     bowerDependencies.map(function(dirname) {
         var filepath = nodePath.resolve(cwd, folder, dirname, '.bower.json');
         if (fs.existsSync(filepath)) {

--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -65,7 +65,7 @@ function getAllDependencies() {
     var bowerDependencies = fs.readdirSync(folder, {encoding: 'utf8'});
 
     var dependencyInfos = [];
-    bowerDependencies.map(function(dirname) {
+    bowerDependencies.forEach(function(dirname) {
         var filepath = nodePath.resolve(cwd, folder, dirname, '.bower.json');
         if (fs.existsSync(filepath)) {
             var dependencyInfo = getDependency(filepath);

--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -13,7 +13,7 @@ var cwd = process.cwd();
 function mapDependencyData(bowerInfo) {
     return {
         name: bowerInfo.name,
-        commit: bowerInfo._resolution.commit,
+        commit: bowerInfo._resolution !== undefined ? bowerInfo._resolution.commit : undefined,
         release: bowerInfo._release,
         src: bowerInfo._source,
         originalSrc: bowerInfo._originalSource

--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -32,13 +32,39 @@ function getDependency(filepath) {
 }
 
 /**
+ * Gets the Bower RC data
+ * @returns {Object|null} Returns the JSON objects from the file if it's found, null otherwise
+ */
+function getBowerRC() {
+    if (fs.existsSync('.bowerrc')) {
+        return JSON.parse(fs.readFileSync('.bowerrc', {encoding: 'utf8'}));
+    }
+
+    return null;
+}
+
+/**
+ * Gets the folder in which Bower components are stored
+ * @returns {String}
+ */
+function getBowerFolder() {
+    var bowerRC = getBowerRC();
+    if (bowerRC === null || bowerRC.directory === undefined) {
+        return 'bower_components';
+    }
+
+    return bowerRC.directory;
+}
+
+/**
  * Function to return the metadata for all the dependencies loaded within the `bower_components` directory
  * @returns {Object} Returns dependency object for each dependency containing (dirName, commit, release, src, etc.)
  */
 function getAllDependencies() {
-    var bowerDependencies = fs.readdirSync('./bower_components', {encoding: 'utf8'});
+    var folder = './' + getBowerFolder();
+    var bowerDependencies = fs.readdirSync(folder, {encoding: 'utf8'});
     return bowerDependencies.map(function(dirname) {
-        var filepath = nodePath.resolve(cwd, './bower_components', dirname, '.bower.json');
+        var filepath = nodePath.resolve(cwd, folder, dirname, '.bower.json');
         var dependencyInfo = getDependency(filepath);
         dependencyInfo.dirName = dirname;
         return dependencyInfo;

--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -63,12 +63,16 @@ function getBowerFolder() {
 function getAllDependencies() {
     var folder = './' + getBowerFolder();
     var bowerDependencies = fs.readdirSync(folder, {encoding: 'utf8'});
-    return bowerDependencies.map(function(dirname) {
+    bowerDependencies.map(function(dirname) {
         var filepath = nodePath.resolve(cwd, folder, dirname, '.bower.json');
-        var dependencyInfo = getDependency(filepath);
-        dependencyInfo.dirName = dirname;
-        return dependencyInfo;
+        if (fs.existsSync(filepath)) {
+            var dependencyInfo = getDependency(filepath);
+            dependencyInfo.dirName = dirname;
+            dependencyInfos.push(dependencyInfo);
+        }
     });
+
+    return dependencyInfos;
 }
 
 module.exports = {

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -47,8 +47,9 @@ function lock(isVerbose) {
     dependencies.forEach(function(dep) {
         // NOTE: Use dirName as the dependency name as it is more accurate than .bower.json properties
         var name = dep.dirName;
-        bowerConfig.dependencies[name] = dep.src + '#' + dep.commit; // _source
-        bowerConfig.resolutions[name] = dep.commit;
+        var version = dep.commit !== undefined ? dep.commit : dep.release;
+        bowerConfig.dependencies[name] = dep.src + '#' + version; // _source
+        bowerConfig.resolutions[name] = version;
         bowerConfig.bowerLocker.lockedVersions[name] = dep.release;
         if (isVerbose) {
             console.log('  %s (%s): %s', name, dep.release, dep.commit);


### PR DESCRIPTION
The Bower folder may contain folders, which are invalid, for example auto generated, forgotten garbage, or even the packages of another package manager. If no valid JSON file is found in the folder, just ignore it (instead of an immediate crash).