### PR TITLE
Depending on release number instaed of commit

### DIFF
--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -11,9 +11,12 @@ var cwd = process.cwd();
  * @returns {{name: String, commit: String, release: String, src: String, originalSrc: String}}
  */
 function mapDependencyData(bowerInfo) {
+	var commitValue = bowerInfo._resolution
+						? bowerInfo._resolution.commit
+						: '';
     return {
         name: bowerInfo.name,
-        commit: bowerInfo._resolution.commit,
+        commit: commitValue,
         release: bowerInfo._release,
         src: bowerInfo._source,
         originalSrc: bowerInfo._originalSource

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -48,6 +48,10 @@ function lock(isVerbose) {
 		}
 	};
 	
+	bowerConfig.resolutions = bowerConfig.resolutions
+								? bowerConfig.resolutions
+								: {};
+	
 	//Iterate over dependecies found and set the version number as it found or as it was if not found. 
     dependencies.forEach(function(dep) {
         // NOTE: Use dirName as the dependency name as it is more accurate than .bower.json properties
@@ -80,7 +84,7 @@ function setReleaseValue(bowerConfig,dep, validVersionNumber) {
 		
 		bowerConfig.dependencies[name] = validVersionNumber
 											? dep.release
-											: bowerConfig.dependencies[name];		
+											: bowerConfig.dependencies[name];											
 	}
 	
 	if(bowerConfig.devDependencies && bowerConfig.devDependencies[name])		
@@ -90,6 +94,13 @@ function setReleaseValue(bowerConfig,dep, validVersionNumber) {
 		bowerConfig.devDependencies[name] = validVersionNumber
 												? dep.release
 												: bowerConfig.devDependencies[name];
+	}
+	
+	if(validVersionNumber)
+	{
+		bowerConfig.resolutions[name] = bowerConfig.resolutions[name]
+											? bowerConfig.resolutions[name]
+											: dep.release;
 	}
 }
 

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -74,7 +74,7 @@ function lock(isVerbose) {
 
 function setReleaseValue(bowerConfig,dep, validVersionNumber) {
 	var name = dep.dirName;
-	if(bowerConfig.dependencies[name])
+	if(bowerConfig.dependencies && bowerConfig.dependencies[name])
 	{
 		bowerConfig.bowerLocker.originalVersions.dependencies[name] = bowerConfig.dependencies[name];
 		
@@ -83,7 +83,7 @@ function setReleaseValue(bowerConfig,dep, validVersionNumber) {
 											: bowerConfig.dependencies[name];		
 	}
 	
-	if(bowerConfig.devDependencies[name])		
+	if(bowerConfig.devDependencies && bowerConfig.devDependencies[name])		
 	{
 		bowerConfig.bowerLocker.originalVersions.devDependencies[name] = bowerConfig.devDependencies[name];
 		

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "commander": "~2.9.0",
-    "json-format": "~0.1.2"
+    "json-format": "~0.1.2",
+	"semver": "~1.0.0"
   }
 }


### PR DESCRIPTION
- Replaced the old way of depending on `commit` with new one depending on `release number` only, and even check if release number is valid one (coz some packages doesn't have one either).

- Added resolution for all packages to solve incompatibly questions that may appear during the installation.